### PR TITLE
Drop semi-colon from query header comment

### DIFF
--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -131,7 +131,7 @@ class PrestoQueryEngine(QueryEngine):
     def user_agent(self):
         """User agent passed to a Presto connection.
         """
-        return "pytd/{0} (Presto; prestodb/{1})".format(__version__, prestodb.__version__)
+        return "pytd/{0} (prestodb/{1})".format(__version__, prestodb.__version__)
 
     def cursor(self):
         """Get cursor defined by DB-API.
@@ -186,7 +186,7 @@ class HiveQueryEngine(QueryEngine):
     def user_agent(self):
         """User agent passed to a Hive connection.
         """
-        return "pytd/{0} (Hive; tdclient/{1})".format(__version__, tdclient.__version__)
+        return "pytd/{0} (tdclient/{1})".format(__version__, tdclient.__version__)
 
     def cursor(self):
         """Get cursor defined by DB-API.

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -21,7 +21,7 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
 
     def test_user_agent(self):
         ua = self.presto.user_agent
-        self.assertEquals(ua, 'pytd/%s (Presto; prestodb/%s)' % (__version__, prestodb.__version__))
+        self.assertEquals(ua, 'pytd/%s (prestodb/%s)' % (__version__, prestodb.__version__))
 
     def test_create_header(self):
         presto_no_header = PrestoQueryEngine('1/XXX', 'https://api.treasuredata.com/', 'sample_datasets', False)
@@ -59,7 +59,7 @@ class HiveQueryEngineTestCase(unittest.TestCase):
         self.assertEquals(hive_no_header.create_header('foo'), '')
 
         ua = self.hive.user_agent
-        self.assertEquals(ua, 'pytd/%s (Hive; tdclient/%s)' % (__version__, tdclient.__version__))
+        self.assertEquals(ua, 'pytd/%s (tdclient/%s)' % (__version__, tdclient.__version__))
 
     def test_create_header(self):
         ua = self.hive.user_agent


### PR DESCRIPTION
In Hive, semi-colon causes query failure even if it's in comment.